### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=ESP8266 Generate QRCode version 7 for SSD1306 oled displays 128*64 pix
 category=Display
 url=https://github.com/anunpanya/ESP8266_QRcode
 architectures=esp8266
+depends=ESP8266 and ESP32 OLED driver for SSD1306 displays


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format