### PR TITLE
Add compability for ESP-IDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(COMPONENT_ADD_INCLUDEDIRS src)
+set(COMPONENT_PRIV_REQUIRES esp8266-oled-ssd1306)
+set(COMPONENT_SRCDIRS src)
+register_component()

--- a/component.mk
+++ b/component.mk
@@ -1,0 +1,3 @@
+COMPONENT_ADD_INCLUDEDIRS := src
+COMPONENT_SRCDIRS := src
+CXXFLAGS += -Wno-ignored-qualifiers


### PR DESCRIPTION
These 2 files allow to use your QR lib with the ESP-IDF

it has a dependency on "ESP8266 Oled Driver for SSD1306 display by Daniel Eichborn, Fabrice Weinberg" which is already compatible to ESP-IDF